### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,10 +13,11 @@ AllCops:
     - '**/Rakefile'
     - '**/Vagrantfile'
     - '**/db/schema.rb'
-  DisplayCopNames: true
   TargetRubyVersion: 2.5
   TargetRailsVersion: 5.2
 
+Layout/ClassStructure:
+  Enabled: true
 Layout/FirstArrayElementLineBreak:
   Enabled: true
 Layout/FirstHashElementLineBreak:
@@ -66,6 +67,18 @@ Metrics/PerceivedComplexity:
 
 Naming/AccessorMethodName:
   Enabled: false
+Naming/UncommunicativeBlockParamName:
+  AllowedNames:
+    - id
+    - x
+    - y
+    - _
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - id
+    - x
+    - y
+    - _
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 
@@ -103,6 +116,8 @@ RSpec/DescribeClass:
     - '**/spec/features/**/*'
 RSpec/ExampleLength:
   Enabled: false
+RSpec/ExpectChange:
+  EnforcedStyle: block
 RSpec/LeadingSubject:
   Enabled: false
 RSpec/MessageChain:
@@ -130,6 +145,8 @@ Style/ConditionalAssignment:
 Style/Documentation:
   Exclude:
     - '**/controllers/**/*'
+Style/EmptyLineAfterGuardClause:
+  Enabled: true
 Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/FormatStringToken:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+# rubocop version: 0.57.2
+# rubocop-rspec version: 1.27.0
+
 require: rubocop-rspec
 
 AllCops:
@@ -145,12 +148,12 @@ Style/ConditionalAssignment:
 Style/Documentation:
   Exclude:
     - '**/controllers/**/*'
-Style/EmptyLineAfterGuardClause:
-  Enabled: true
 Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/FormatStringToken:
   Enabled: false
+Style/IpAddresses:
+  Enabled: true
 Style/Lambda:
   EnforcedStyle: literal
 Style/NumericPredicate:
@@ -170,6 +173,8 @@ Style/StringMethods:
 # Defaults; may make sense to turn off for specific projects
 Layout/CaseIndentation:
   Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
 
 Rails/SaveBang:
   Enabled: true


### PR DESCRIPTION
This updates our .rubocop.yml based on the latest changed to rubocop and rubocop-rspec. For context, here are the cops that have been added since the last time we updated this file:

[FactoryBot/StaticAttributeDefinedDynamically](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb)
[FactoryBot/CreateList](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/factory_bot/create_list.rb)

[Gemspec/DuplicatedAssignment](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/gemspec/duplicated_assignment.rb)
[Gemspec/RequiredRubyVersion](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/gemspec/required_ruby_version.rb)

[Layout/ClassStructure](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/class_structure.rb)*
[Layout/EmptyComment](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/empty_comment.rb)
[Layout/EmptyLinesAroundArguments](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/empty_lines_around_arguments.rb)
[Layout/SpaceInsideArrayLiteralBrackets](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/space_inside_array_literal_brackets.rb)
[Layout/SpaceInsideReferenceBrackets](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/layout/space_inside_reference_brackets.rb)

[Lint/BigDecimalNew](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/big_decimal_new.rb)
[Lint/MissingCopEnableDirective](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/missing_cop_enable_directive.rb)
[Lint/NumberConversion](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/number_conversion.rb)*
[Lint/OrderedMagicComments](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/ordered_magic_comments.rb)
[Lint/SafeNavigationConsistency](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/safe_navigation_consistency.rb)
[Lint/ShadowedArgument](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/shadowed_argument.rb)
[Lint/UnneededCopEnableDirective](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/lint/unneeded_cop_enable_directive.rb)

[Naming/MemoizedInstanceVariableName](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/naming/memoized_instance_variable_name.rb)
[Naming/UncommunicativeBlockParamName](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/naming/uncommunicative_block_param_name.rb)*
[Naming/UncommunicativeMethodParamName8](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/naming/uncommunicative_method_param_name.rb)*

[Performance/UnneededSort](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/performance/unneeded_sort.rb)

[Rails/ActiveRecordAliases](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/active_record_aliases.rb)
[Rails/AssertNot](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/assert_not.rb)
[Rails/CreateTableWithTimestamps](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/create_table_with_timestamps.rb)
[Rails/EnvironmentComparison](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/environment_comparison.rb)
[Rails/HttpStatus](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/http_status.rb)
[Rails/InverseOf](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/inverse_of.rb)
[Rails/LexicallyScopedActionFilter](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/lexically_scoped_action_filter.rb)
[Rails/Presence](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/presence.rb)
[Rails/RedundantReceiverInWithOptions](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/redundant_receiver_in_with_options.rb)
[Rails/RefuteMethods](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/refute_methods.rb)

[RSpec/Be](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/be.rb)
[RSpec/ExampleWithoutDescription](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/example_without_description.rb)
[RSpec/ExpectChange](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/expect_change.rb)
[RSpec/Pending](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/pending.rb)*
[RSpec/Rails/HttpStatus](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/rails/http_status.rb)
[RSpec/SharedExamples](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/shared_examples.rb)

[Security/Open](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/security/open.rb)

[Style/ColonMethodDefinition](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/colon_method_definition.rb)
[Style/EmptyBlockParameter](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/empty_block_parameter.rb)
[Style/EmptyLambdaParameter](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/empty_lambda_parameter.rb)
[Style/EmptyLineAfterGuardClause](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/empty_line_after_guard_clause.rb)*
[Style/EvalWithLocation](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/eval_with_location.rb)
[Style/ExpandPathArguments](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/expand_path_arguments.rb)
[Style/RandomWithOffset](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/random_with_offset.rb)
[Style/StringHashKeys](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/string_hash_keys.rb)*
[Style/TrailingBodyOnClass](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_body_on_class.rb)
[Style/TrailingBodyOnMethodDefinition](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_body_on_method_definition.rb)
[Style/TrailingBodyOnModule](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_body_on_module.rb)
[Style/TrailingCommaInArrayLiteral](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_comma_in_array_literal.rb)
[Style/TrailingCommaInHashLiteral](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_comma_in_hash_literal.rb)
[Style/TrailingMethodEndStatment](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/trailing_method_end_statement.rb)
[Style/UnpackFirst](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/unpack_first.rb)


\* New cop that is disabled by default